### PR TITLE
add state value as a verification param for K8s pods

### DIFF
--- a/pkg/cmd/verify.go
+++ b/pkg/cmd/verify.go
@@ -9,7 +9,6 @@ import (
 	"github.com/cnoe-io/cnoe-cli/pkg/lib"
 	"github.com/hashicorp/go-multierror"
 	"github.com/spf13/cobra"
-	v1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -91,10 +90,10 @@ func Verify(stdout, stderr io.Writer, cli lib.IK8sClient, configs []lib.Config) 
 
 				if strings.Contains(p.GetName(), pid.Name) {
 					found = true
-					if p.Status.Phase == v1.PodRunning {
+					if string(p.Status.Phase) == pid.State {
 						fmt.Fprintf(stdout, "%s %s - %s, Pod=%s - %s\n", green("✓"), config.Metadata.Name, p.GetNamespace(), p.GetName(), p.Status.Phase)
 					} else {
-						fmt.Fprintf(stdout, "%s %s - %s, Pod=%s - %s\n", red("X"), config.Metadata.Name, p.GetNamespace(), p.GetName(), p.Status.Phase)
+						fmt.Fprintf(stdout, "%s %s - %s, Pod=%s - %s != %s \n", red("X"), config.Metadata.Name, p.GetNamespace(), p.GetName(), p.Status.Phase, pid.State)
 						result = multierror.Append(result, errors.New(fmt.Sprintf("%s, Pod=%s failed", p.GetNamespace(), p.GetName())))
 					}
 				}

--- a/pkg/lib/config.go
+++ b/pkg/lib/config.go
@@ -9,6 +9,7 @@ type CRD struct {
 type Pod struct {
 	Name      string `yaml:"name"`
 	Namespace string `yaml:"namespace"`
+	State     string `yaml:"state"`
 }
 
 type Spec struct {


### PR DESCRIPTION
State of a pod is a critical part of doing verifications. Particularly for jobs that are expected to be completed.

This change allows for the expected state to be defined in the verification file.