### PR TITLE
fix integer type handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	golang.org/x/mod v0.11.0 // indirect
 	golang.org/x/net v0.11.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b // indirect
-	golang.org/x/sys v0.9.0 // indirect
+	golang.org/x/sys v0.12.0 // indirect
 	golang.org/x/term v0.9.0 // indirect
 	golang.org/x/text v0.10.0 // indirect
 	golang.org/x/time v0.0.0-20220210224613-90d013bbcef8 // indirect

--- a/pkg/cmd/crd.go
+++ b/pkg/cmd/crd.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/cnoe-io/cnoe-cli/pkg/models"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
 )
 
 const (
@@ -182,7 +182,7 @@ func (c *CRDModule) convert(def string) (any, string, error) {
 
 	var resourceName string
 	if doc.Spec.ClaimNames != nil {
-		resourceName = doc.Spec.ClaimNames.Kind
+		resourceName = fmt.Sprintf("%s.%s", doc.Spec.Group, doc.Spec.ClaimNames.Kind)
 	} else {
 		resourceName = fmt.Sprintf("%s.%s", doc.Spec.Group, doc.Spec.Names.Kind)
 	}
@@ -218,10 +218,14 @@ func (c *CRDModule) convert(def string) (any, string, error) {
 			"default":     fmt.Sprintf("%s/%s", doc.Spec.Group, doc.Spec.Versions[0].Name),
 		},
 			"properties", "apiVersion")
+		kind := doc.Spec.Names.Kind
+		if doc.Spec.ClaimNames != nil {
+			kind = doc.Spec.ClaimNames.Kind
+		}
 		unstructured.SetNestedMap(obj.Object, map[string]interface{}{
 			"type":        "string",
 			"description": "Kind for the resource",
-			"default":     doc.Spec.Names.Kind,
+			"default":     kind,
 		},
 			"properties", "kind")
 	}

--- a/pkg/cmd/fakes/crd/valid/input/cdn.yaml
+++ b/pkg/cmd/fakes/crd/valid/input/cdn.yaml
@@ -23,6 +23,10 @@ spec:
           properties:
             spec:
               properties:
+                minSize:
+                  type: integer
+                  default: 2
+                  description: Min Size.
                 resourceConfig:
                   description: ResourceConfig defines general properties of this AWS
                     resource.

--- a/pkg/cmd/fakes/crd/valid/output/full-template-awsblueprints.io.cdn.yaml
+++ b/pkg/cmd/fakes/crd/valid/output/full-template-awsblueprints.io.cdn.yaml
@@ -15,6 +15,10 @@ spec:
           type: string
         config:
           properties:
+            minSize:
+              type: integer
+              default: 2
+              description: Min Size.
             resourceConfig:
               description: ResourceConfig defines general properties of this AWS resource.
               properties:
@@ -50,10 +54,10 @@ spec:
               type: object
           required:
             - resourceConfig
-          title: awsblueprints.io.XCDN configuration options
+          title: awsblueprints.io.CDN configuration options
           type: object
         kind:
-          default: XCDN
+          default: CDN
           description: Kind for the resource
           type: string
         name:

--- a/pkg/cmd/fakes/crd/valid/output/full-template-oneof.yaml
+++ b/pkg/cmd/fakes/crd/valid/output/full-template-oneof.yaml
@@ -10,7 +10,7 @@ spec:
     - dependencies:
         resources:
           oneOf:
-            - $yaml: resources/awsblueprints.io.xcdn.yaml
+            - $yaml: resources/awsblueprints.io.cdn.yaml
             - $yaml: resources/sparkoperator.k8s.io.sparkapplication.yaml
       description: Select a AWS resource to add to your repository.
       properties:
@@ -23,7 +23,7 @@ spec:
           type: string
         resources:
           enum:
-            - awsblueprints.io.xcdn
+            - awsblueprints.io.cdn
             - sparkoperator.k8s.io.sparkapplication
           type: string
       required:

--- a/pkg/cmd/fakes/crd/valid/output/properties-awsblueprints.io.cdn.yaml
+++ b/pkg/cmd/fakes/crd/valid/output/properties-awsblueprints.io.cdn.yaml
@@ -5,6 +5,10 @@ properties:
     type: string
   config:
     properties:
+      minSize:
+        type: integer
+        default: 2
+        description: Min Size.
       resourceConfig:
         description: ResourceConfig defines general properties of this AWS resource.
         properties:
@@ -40,12 +44,12 @@ properties:
         type: object
     required:
       - resourceConfig
-    title: awsblueprints.io.XCDN configuration options
+    title: awsblueprints.io.CDN configuration options
     type: object
   kind:
-    default: XCDN
+    default: CDN
     description: Kind for the resource
     type: string
   resources:
     enum:
-    - awsblueprints.io.xcdn
+      - awsblueprints.io.cdn


### PR DESCRIPTION
Fixes the issue where int is passed to the unstructured calls. 

When you try to run the cli against all composition definitions available in the crossplane on eks repo, the following is shown.

```bash
./main template crd -i ~/repos/crossplane-aws-blueprints/compositions/aws-provider/eks -o /tmp/out --templatePath ~/repos/cnoe/cnoe-cli/config/templates/k8s-apply-template.yaml
2023/09/22 11:05:55 processing 5 definitions
2023/09/22 11:05:55 processing resource at /Users/mccloman/repos/crossplane-aws-blueprints/compositions/aws-provider/eks/autoscaler.yaml
2023/09/22 11:05:55 processing resource at /Users/mccloman/repos/crossplane-aws-blueprints/compositions/aws-provider/eks/definition.yaml
panic: cannot deep copy int
```

The `k8s.io/apimachinery/pkg/runtime.DeepCopyJSONValue` [expects int64 only, not int](https://github.com/kubernetes/apimachinery/blob/a017454658b6eb672eb2d7b5eedad67f5f67665c/pkg/runtime/converter.go#L614). Int type is returned by the yaml library. To ensure int64 is returned, we can just use the k8s yaml library instead. This is less efficient but for generation purposes, I think it's fine. 

As a result of switching the library, the json tags on [the document struct](https://github.com/cnoe-io/cnoe-cli/blob/7e059dfb3f8e057e4e3fcc4642c06e1567ab0f79/pkg/models/structs.go#L12) is [now respected](https://github.com/kubernetes-sigs/yaml/blob/65d71bb2ae7234d12629f43f77e1a44512057bba/yaml.go#L43C1-L43C1). When generating from XRDs, this results in generation of files named with the claim kind only.  (e.g. `cdn.yaml` as opposed to `awsblueprints.io.cdn.yaml`) I don't think naming the file with the kind string is intended. I changed it to follow the same pattern. 
